### PR TITLE
Adding check to see if the selected platform stream is live before embedding

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,12 +14,6 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
               const destinyKickId = "destiny"; // Replace with actual Twitch ID
               const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
-              let embedElement = document.getElementById("embed");
-              if (embedElement) {
-                console.log("Removing existing embed element");
-                embedElement.remove();
-              }
-
               // Check stream live webservice to see if he's live on currently selected platform
               const response = await fetch(destinyLiveWs);
               const liveJson = await response.json();
@@ -31,6 +25,12 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
               // Only embed if stream is live
               if (live) {
+                let embedElement = document.getElementById("embed");
+                if (embedElement) {
+                  console.log("Removing existing embed element");
+                  embedElement.remove();
+                }
+                
                 embedElement = document.createElement("div");
                 embedElement.id = "dgg-embed";
                 embedElement.style.width = "100%";

--- a/background.js
+++ b/background.js
@@ -14,29 +14,23 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
               const destinyKickId = "destiny"; // Replace with actual Twitch ID
               const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
+              let embedElement = document.getElementById("embed");
+              if (embedElement) {
+                console.log("Removing existing embed element");
+                embedElement.remove();
+              }
+
               // Check stream live webservice to see if he's live on currently selected platform
               const response = await fetch(destinyLiveWs);
               const liveJson = await response.json();
-              let streams = liveJson.data.streams;
+              let stream = liveJson.data.streams[platform];
               let live = false;
-              for (let key in streams) {
-                if (key === platform) {
-                  let stream = streams[key];
-                  if (stream != null) {
-                    live = live || stream.live;
-                  }
-                }
+              if (stream != null) {
+                live = stream.live;
               }
 
               // Only embed if stream is live
               if (live) {
-                let embedElement = document.getElementById("embed");
-
-                if (embedElement) {
-                  console.log("Removing existing embed element");
-                  embedElement.remove();
-                }
-
                 embedElement = document.createElement("div");
                 embedElement.id = "dgg-embed";
                 embedElement.style.width = "100%";

--- a/background.js
+++ b/background.js
@@ -12,48 +12,68 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
             try {
               const destinyChannelId = "UC554eY5jNUfDq3yDOJYirOQ";
               const destinyKickId = "destiny"; // Replace with actual Twitch ID
-              let embedElement = document.getElementById("embed");
+              const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
-              if (embedElement) {
-                console.log("Removing existing embed element");
-                embedElement.remove();
+              // Check stream live webservice to see if he's live on currently selected platform
+              const response = await fetch(destinyLiveWs);
+              const liveJson = await response.json();
+              let streams = liveJson.data.streams;
+              let live = false;
+              for (let key in streams) {
+                if (key === platform) {
+                  let stream = streams[key];
+                  if (stream != null) {
+                    live = live || stream.live;
+                  }
+                }
               }
 
-              embedElement = document.createElement("div");
-              embedElement.id = "dgg-embed";
-              embedElement.style.width = "100%";
-              embedElement.style.height = "auto";
-              embedElement.style.aspectRatio = "16 / 9";
+              // Only embed if stream is live
+              if (live) {
+                let embedElement = document.getElementById("embed");
 
-              const iframe = document.createElement("iframe");
-              iframe.style.width = "100%";
-              iframe.style.height = "100%";
-              iframe.style.position = "relative"; // Required for z-index to work
-              iframe.style.zIndex = "9999"; // Bring to the forefront
-              iframe.frameBorder = "0";
+                if (embedElement) {
+                  console.log("Removing existing embed element");
+                  embedElement.remove();
+                }
 
-              // Set the source of the iframe based on the platform
-              if (platform === "youtube") {
-                iframe.src = `https://www.youtube.com/embed/live_stream?channel=${destinyChannelId}`;
-              } else if (platform === "kick") {
-                iframe.src = `https://player.kick.com/${destinyKickId}`;
-              } else {
-                console.error("Unknown platform: " + platform);
-                return;
-              }
+                embedElement = document.createElement("div");
+                embedElement.id = "dgg-embed";
+                embedElement.style.width = "100%";
+                embedElement.style.height = "auto";
+                embedElement.style.aspectRatio = "16 / 9";
 
-              embedElement.appendChild(iframe);
+                const iframe = document.createElement("iframe");
+                iframe.style.width = "100%";
+                iframe.style.height = "100%";
+                iframe.style.position = "relative"; // Required for z-index to work
+                iframe.style.zIndex = "9999"; // Bring to the forefront
+                iframe.frameBorder = "0";
 
-              const streamWrapElement = document.getElementById("stream-wrap");
-              if (streamWrapElement) {
-                streamWrapElement.appendChild(embedElement);
-              } else {
-                console.error("stream-wrap element not found");
+                // Set the source of the iframe based on the platform
+                if (platform === "youtube") {
+                  iframe.src = `https://www.youtube.com/embed/live_stream?channel=${destinyChannelId}`;
+                } else if (platform === "kick") {
+                  iframe.src = `https://player.kick.com/${destinyKickId}`;
+                } else {
+                  console.error("Unknown platform: " + platform);
+                  return;
+                }
+
+                embedElement.appendChild(iframe);
+
+                const streamWrapElement = document.getElementById("stream-wrap");
+                if (streamWrapElement) {
+                  streamWrapElement.appendChild(embedElement);
+                } else {
+                  console.error("stream-wrap element not found");
+                }
               }
             } catch (error) {
               console.error("Error:", error);
             }
           }
+
           // Call the function after defining it
           embedVideo(platform);
         },

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -11,46 +11,65 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   }
 });
 
-function embedVideo(platform) {
+async function embedVideo(platform) {
   // embedVideo function definition here
   const destinyChannelId = "UC554eY5jNUfDq3yDOJYirOQ";
   const destinyKickId = "destiny"; // Replace with actual Twitch ID
-  let embedElement = document.getElementById("embed");
+  const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
-  if (embedElement) {
-    console.log("Removing existing embed element");
-    embedElement.remove();
+  // Check stream live webservice to see if he's live on currently selected platform
+  const response = await fetch(destinyLiveWs);
+  const liveJson = await response.json();
+  let streams = liveJson.data.streams;
+  let live = false;
+  for (let key in streams) {
+    if (key === platform) {
+      let stream = streams[key];
+      if (stream != null) {
+        live = live || stream.live;
+      }
+    }
   }
 
-  embedElement = document.createElement("div");
-  embedElement.id = "dgg-embed";
-  embedElement.style.width = "100%";
-  embedElement.style.height = "auto";
-  embedElement.style.aspectRatio = "16 / 9";
+  // Only embed if stream is live
+  if (live) {
+    let embedElement = document.getElementById("embed");
 
-  const iframe = document.createElement("iframe");
-  iframe.style.width = "100%";
-  iframe.style.height = "100%";
-  iframe.style.position = "relative"; // Required for z-index to work
-  iframe.style.zIndex = "9999"; // Bring to the forefront
-  iframe.frameBorder = "0";
+    if (embedElement) {
+      console.log("Removing existing embed element");
+      embedElement.remove();
+    }
 
-  // Set the source of the iframe based on the platform
-  if (platform === "youtube") {
-    iframe.src = `https://www.youtube.com/embed/live_stream?channel=${destinyChannelId}`;
-  } else if (platform === "kick") {
-    iframe.src = `https://player.kick.com/${destinyKickId}`;
-  } else {
-    console.error("Unknown platform: " + platform);
-    return;
-  }
+    embedElement = document.createElement("div");
+    embedElement.id = "dgg-embed";
+    embedElement.style.width = "100%";
+    embedElement.style.height = "auto";
+    embedElement.style.aspectRatio = "16 / 9";
 
-  embedElement.appendChild(iframe);
+    const iframe = document.createElement("iframe");
+    iframe.style.width = "100%";
+    iframe.style.height = "100%";
+    iframe.style.position = "relative"; // Required for z-index to work
+    iframe.style.zIndex = "9999"; // Bring to the forefront
+    iframe.frameBorder = "0";
 
-  const streamWrapElement = document.getElementById("stream-wrap");
-  if (streamWrapElement) {
-    streamWrapElement.appendChild(embedElement);
-  } else {
-    console.error("stream-wrap element not found");
+    // Set the source of the iframe based on the platform
+    if (platform === "youtube") {
+      iframe.src = `https://www.youtube.com/embed/live_stream?channel=${destinyChannelId}`;
+    } else if (platform === "kick") {
+      iframe.src = `https://player.kick.com/${destinyKickId}`;
+    } else {
+      console.error("Unknown platform: " + platform);
+      return;
+    }
+
+    embedElement.appendChild(iframe);
+
+    const streamWrapElement = document.getElementById("stream-wrap");
+    if (streamWrapElement) {
+      streamWrapElement.appendChild(embedElement);
+    } else {
+      console.error("stream-wrap element not found");
+    }
   }
 }

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -17,12 +17,6 @@ async function embedVideo(platform) {
   const destinyKickId = "destiny"; // Replace with actual Twitch ID
   const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
-  let embedElement = document.getElementById("embed");
-  if (embedElement) {
-    console.log("Removing existing embed element");
-    embedElement.remove();
-  }
-
   // Check stream live webservice to see if he's live on currently selected platform
   const response = await fetch(destinyLiveWs);
   const liveJson = await response.json();
@@ -34,6 +28,12 @@ async function embedVideo(platform) {
 
   // Only embed if stream is live
   if (live) {
+    let embedElement = document.getElementById("embed");
+    if (embedElement) {
+      console.log("Removing existing embed element");
+      embedElement.remove();
+    }
+    
     embedElement = document.createElement("div");
     embedElement.id = "dgg-embed";
     embedElement.style.width = "100%";

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -17,29 +17,23 @@ async function embedVideo(platform) {
   const destinyKickId = "destiny"; // Replace with actual Twitch ID
   const destinyLiveWs = "https://www.destiny.gg/api/info/stream";
 
+  let embedElement = document.getElementById("embed");
+  if (embedElement) {
+    console.log("Removing existing embed element");
+    embedElement.remove();
+  }
+
   // Check stream live webservice to see if he's live on currently selected platform
   const response = await fetch(destinyLiveWs);
   const liveJson = await response.json();
-  let streams = liveJson.data.streams;
+  let stream = liveJson.data.streams[platform];
   let live = false;
-  for (let key in streams) {
-    if (key === platform) {
-      let stream = streams[key];
-      if (stream != null) {
-        live = live || stream.live;
-      }
-    }
+  if (stream != null) {
+    live = stream.live;
   }
 
   // Only embed if stream is live
   if (live) {
-    let embedElement = document.getElementById("embed");
-
-    if (embedElement) {
-      console.log("Removing existing embed element");
-      embedElement.remove();
-    }
-
     embedElement = document.createElement("div");
     embedElement.id = "dgg-embed";
     embedElement.style.width = "100%";


### PR DESCRIPTION
Uses https://www.destiny.gg/api/info/stream web service to check live status.

This change allows you to embed other streams on DGG Bigscreen when Destiny is not live so I don't have to disable the extension every time he is not live.

I copied the change to the Firefox background.js as well, but did not test on Firefox as it would not load the manifest.json file for some reason. I'm sure it's something I am just unfamiliar with as just copying the code from main directly still does not like the manifest file. Please take a look at it there before publishing!